### PR TITLE
Ignore push event without commits

### DIFF
--- a/scripts/generate-events.py
+++ b/scripts/generate-events.py
@@ -139,6 +139,8 @@ def generate_content(event, user, seen):
 
     # Content for description on the kind of event
     if event_type == "PushEvent":
+        if not event["payload"]["commits"]:
+            return None
         commit_url = "%s/commit/%s" % (repo, event["payload"]["commits"][-1]["sha"])
         message = event["payload"]["commits"][-1]["message"]
         description = (


### PR DESCRIPTION
I'm not sure what causes this, but it just triggered in one of the runs:

```bash
Traceback (most recent call last):
  File "/generate-events.py", line 361, in <module>
    main()
  File "/generate-events.py", line 357, in main
    write_events(events, output_dir)
  File "/generate-events.py", line 282, in write_events
    content = generate_content(event, username, seen)
  File "/generate-events.py", line 142, in generate_content
    commit_url = "%s/commit/%s" % (repo, event["payload"]["commits"][-1]["sha"])
IndexError: list index out of range
```
Actually, it's probably just an empty push (which is allowed with `--allow-empty`)